### PR TITLE
Add Server Regex Support

### DIFF
--- a/docs/README.newrelic.md
+++ b/docs/README.newrelic.md
@@ -52,8 +52,10 @@ This configuration file also acts as a fileconfig for the logger.  See [fileConf
 | Option | Description | Required? | Default |
 | ------ | ----------- | ------- | ------- |
 | names | Comma-separated list of specific names to retrieve | No | None |
-| regex | Comma-separated list of regular expressions to match against results of the metrics.json calls.  White list.  Matches are retrieved from data.json. | No | None |
-| blacklist_regex | Comma-separated list of regular expressions to not include. Black list trumps white list. | No | None |
+| regex | Comma-separated list of regular expressions to match against results of the metrics.json calls for hosts.  White list.  Matches are retrieved from data.json. | No | None |
+| blacklist_regex | Comma-separated list of regular expressions to not include for hosts. Black list trumps white list. | No | None |
+| server_regex | Comma-separated list of regular expressions to match against results of the metrics.json calls for servers.  White list.  Matches are retrieved from data.json. | No | None |
+| server_blacklist_regex | Comma-separated list of regular expressions to not include for servers. Black list trumps white list. | No | None |
 | additional_fields | Comma-separated list of metric names to retrieve in addition to the ones returned by metrics.json calls.  By default, you probably will want to include `HttpDispatcher,Errors,Memcached,External` | No | None |
 | application_ids | Comma-separated list of New Relic application IDs to retrieve metrics from | No | All |
 | start_time | Start time for range based backfilling query (YYYY-MM-DDTHH:mm:ss+00:00) | No | None |

--- a/test/test_newrelic.py
+++ b/test/test_newrelic.py
@@ -1,0 +1,31 @@
+import sys
+import unittest
+import re
+
+sys.path.append('..')
+from wavefront.newrelic import NewRelicMetricRetrieverCommand
+
+class TestNewRelicCommand(unittest.TestCase):
+    def test_whitelist_blacklist(self):
+        fields = ['WebTransaction/GoodCall/1', 'OtherTransaction/GoodCall/1', 'WebTransaction/BadCall/1']
+
+        whitelist = ['WebTransaction.*', 'OtherTransaction.*']
+        whitelist_compiled = []
+        for regex in whitelist:
+            whitelist_compiled.append(re.compile(regex))
+
+        blacklist = ['WebTransaction\/BadCall.*']
+        blacklist_compiled = []
+        for regex in blacklist:
+            blacklist_compiled.append(re.compile(regex))
+
+        cmd = NewRelicMetricRetrieverCommand()
+        result = cmd._filter_fields_by_regex(fields, whitelist, whitelist_compiled, blacklist, blacklist_compiled)
+
+        assert 'WebTransaction/GoodCall/1' in result
+        assert 'OtherTransaction/GoodCall/1' in result
+        assert 'WebTransaction/BadCall/1' not in result
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add support for server regex whitelist/blacklist. When we go fetch metrics, the code currently grabs all metric names, then grabs each one individually. While we can control this for hosts via the regex/blacklist_regex whitelist/blacklist, we don't have one for the server metrics. This adds that support for servers.