### PR TITLE
[feature/application-metrics] Add app metrics support

### DIFF
--- a/docs/README.newrelic.md
+++ b/docs/README.newrelic.md
@@ -54,6 +54,8 @@ This configuration file also acts as a fileconfig for the logger.  See [fileConf
 | names | Comma-separated list of specific names to retrieve | No | None |
 | regex | Comma-separated list of regular expressions to match against results of the metrics.json calls for hosts.  White list.  Matches are retrieved from data.json. | No | None |
 | blacklist_regex | Comma-separated list of regular expressions to not include for hosts. Black list trumps white list. | No | None |
+| app_regex | Comma-separated list of regular expressions to match against results of the metrics.json calls for application.  White list.  Matches are retrieved from data.json. | No | None |
+| app_blacklist_regex | Comma-separated list of regular expressions to not include for application. Black list trumps white list. | No | None |
 | server_regex | Comma-separated list of regular expressions to match against results of the metrics.json calls for servers.  White list.  Matches are retrieved from data.json. | No | None |
 | server_blacklist_regex | Comma-separated list of regular expressions to not include for servers. Black list trumps white list. | No | None |
 | additional_fields | Comma-separated list of metric names to retrieve in addition to the ones returned by metrics.json calls.  By default, you probably will want to include `HttpDispatcher,Errors,Memcached,External` | No | None |
@@ -65,6 +67,7 @@ This configuration file also acts as a fileconfig for the logger.  See [fileConf
 | Option | Description | Required? | Default |
 | ------ | ----------- | ------- | ------- |
 | include_application_summary | Include the summary metrics from the application API (error_rate, etc) | No | True |
+| include_application_detail | Include the application metrics from the /application API | No | False |
 | include_host_application_summary | Include the summary metrics from the /host/application API | No | True |
 | include_hosts | Include the host metrics from /host/data.json | No | True |
 | include_server_summary | Include the summary details from the /servers/data.json API | No | True |

--- a/test/test-conf/test-newrelic-details.conf
+++ b/test/test-conf/test-newrelic-details.conf
@@ -1,0 +1,22 @@
+[api]
+key = YOUR_API_KEY
+
+[filter]
+application_ids = APP_ID_1,APP_ID_2
+app_regex = WebTransaction.*,OtherTransaction.*
+app_blacklist_regex = WebTransaction\/BadCall.*
+
+[options]
+include_server_summary = False
+include_server_details = False
+include_application_summary = False
+include_application_details = True
+include_host_application_summary = True
+include_hosts = True
+workers = 20
+max_metric_names = 25
+
+[writer]
+host = 127.0.0.1
+port = 2878
+dry_run = True

--- a/test/test_newrelic.py
+++ b/test/test_newrelic.py
@@ -1,13 +1,28 @@
+import mock
 import sys
 import unittest
 import re
+import os
+from dateutil.parser import parse
 
 sys.path.append('..')
 from wavefront.newrelic import NewRelicMetricRetrieverCommand
+from wavefront.newrelic import NewRelicPluginConfiguration
+
 
 class TestNewRelicCommand(unittest.TestCase):
+    def setUp(self):
+        self.start = parse('2017-03-01T00:00:00+00:00')
+        self.end = parse('2017-03-01T00:10:00+00:00')
+        self.app_id = 123
+        self.app_name = 'test_app'
+
+
     def test_whitelist_blacklist(self):
-        fields = ['WebTransaction/GoodCall/1', 'OtherTransaction/GoodCall/1', 'WebTransaction/BadCall/1']
+        metric_name_1 = 'WebTransaction/GoodCall/1'
+        metric_name_2 = 'OtherTransaction/GoodCall/1'
+        metric_name_3 = 'WebTransaction/BadCall/1'
+        fields = [metric_name_1, metric_name_2, metric_name_3]
 
         whitelist = ['WebTransaction.*', 'OtherTransaction.*']
         whitelist_compiled = []
@@ -20,12 +35,59 @@ class TestNewRelicCommand(unittest.TestCase):
             blacklist_compiled.append(re.compile(regex))
 
         cmd = NewRelicMetricRetrieverCommand()
+
         result = cmd._filter_fields_by_regex(fields, whitelist, whitelist_compiled, blacklist, blacklist_compiled)
 
         assert 'WebTransaction/GoodCall/1' in result
         assert 'OtherTransaction/GoodCall/1' in result
         assert 'WebTransaction/BadCall/1' not in result
 
+    def test_send_metrics_for_application(self):
+        metric_name_1 = 'WebTransaction/GoodCall/1'
+        metric_name_2 = 'OtherTransaction/GoodCall/1'
+        metric_name_3 = 'WebTransaction/BadCall/1'
+        fields = [metric_name_1, metric_name_2, metric_name_3]
+
+        cmd = NewRelicMetricRetrieverCommand()
+        cmd.config = NewRelicPluginConfiguration(config_file_path=os.path.join(os.getcwd(), 'test-conf/test-newrelic-details.conf'))
+
+        with mock.patch('wavefront.newrelic.NewRelicMetricRetrieverCommand.get_metrics_for_path', return_value=None) as metric_path_call, \
+                mock.patch('wavefront.newrelic.NewRelicMetricRetrieverCommand.get_metric_names_for_path', return_value = fields) as metric_name_call:
+
+            cmd.send_metrics_for_overall_application(self.app_id, self.app_name, self.start, self.end)
+
+            assert metric_path_call.called
+            assert metric_path_call.call_count == 1
+            mpc_args, mpc_kwargs = metric_path_call.call_args
+            assert mpc_args == ('/applications/'+ str(self.app_id),
+                                [metric_name_1, metric_name_2],
+                                self.start, self.end,
+                                self.app_name,
+                                { 'app_id': self.app_id,'app_name': self.app_name })
+
+            assert metric_name_call.called
+            assert metric_name_call.call_count == 1
+            mnc_args, mnc_kwargs = metric_name_call.call_args
+            assert mnc_args == ('/applications/' + str(self.app_id), [])
+
+    def test_send_metrics_for_application_config_short_circuit(self):
+        cmd = NewRelicMetricRetrieverCommand()
+
+        cmd.config = NewRelicPluginConfiguration(
+            config_file_path=os.path.join(os.getcwd(), 'test-conf/test-newrelic-details.conf'))
+
+        cmd.config.include_application_details = False
+
+        cmd.send_metrics_for_overall_application(self.app_id, self.app_name, self.start, self.end)
+
+        with mock.patch('wavefront.newrelic.NewRelicMetricRetrieverCommand.get_metric_names_for_path') as metric_name_call:
+            assert not metric_name_call.called
+
+    def tearDown(self):
+        self.start = None
+        self.end = None
+        self.app_id = None
+        self.app_name = None
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add support to directly calling app metrics, instead of
divided by host. Calling for each individual host can sometimes
be too granular and create too many API calls, especially
considering the common issues of overload protection from
New Relic, and most APM metrics on New Relic's side are
app generalized anyways.