### PR TITLE
[feature/application-metrics] Preserve last run time for new relic runs

### DIFF
--- a/wavefront/newrelic.py
+++ b/wavefront/newrelic.py
@@ -404,6 +404,8 @@ class NewRelicMetricRetrieverCommand(NewRelicCommand):
             # construct start time for when to get metrics starting from
             if self.config.start_time:
                 start = self.config.start_time
+            elif self.config.get_last_run_time():
+                start = self.config.get_last_run_time()
             else:
                 start = ((datetime.datetime.utcnow() -
                           datetime.timedelta(seconds=60.0))


### PR DESCRIPTION
Set the start date of a new run to last run time if there is one. This will
allow for in between fills, instead of constantly getting reset and only
polling for a minute.