### PR TITLE
[feature/raw-toggle] Allow for configurability of raw values

### DIFF
--- a/docs/README.newrelic.md
+++ b/docs/README.newrelic.md
@@ -73,6 +73,7 @@ This configuration file also acts as a fileconfig for the logger.  See [fileConf
 | include_server_summary | Include the summary details from the /servers/data.json API | No | True |
 | include_server_details | Include the server metrics from the /servers/data.json API | No | False |
 | min_delay | The minimum number of seconds between the last run time and the current run time | No | 60 |
+| use_raw | Have new relic return raw values | No | True |
 | skip_null_values | Do not include metrics with null values (0 is not null in this case) | No | False |
 | default_null_value | If including null values, then replace 'null' with this value | No | 0 |
 | max_metric_names | Maximum number of metric names to request at one time when querying `/data.json` API | No | 25 |

--- a/wavefront/newrelic.py
+++ b/wavefront/newrelic.py
@@ -98,6 +98,7 @@ class NewRelicPluginConfiguration(command.CommandConfiguration):
             'options', 'include_server_details', False)
 
         self.include_hosts = self.getboolean('options', 'include_hosts', True)
+        self.use_raw = self.getboolean('options', 'use_raw', True)
         self.min_delay = int(self.get('options', 'min_delay', 60))
         self.wf_api_key = self.get('wavefront_api', 'key', '')
         self.wf_api_endpoint = self.get(
@@ -662,7 +663,7 @@ class NewRelicMetricRetrieverCommand(NewRelicCommand):
                 'from': start.isoformat(),
                 'to': end.isoformat(),
                 'names[]': fields_to_get_temp[0:self.config.max_metric_names],
-                'raw': True,
+                'raw': self.config.use_raw,
                 'summarize': False
             }
             del fields_to_get_temp[0:self.config.max_metric_names]


### PR DESCRIPTION
New Relic API has as configurable value that determines if it
returns raw or sanitized values. This allows for configurability
at the wavefront config level. This is useful for certain queries
like call count, where the raw values don't always make sense as
decimals.