### PR TITLE
[feature/split-application-search] Split application search by name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except (IOError, ImportError):
 
 setuptools.setup(
     name='wavefront_collector',
-    version='0.0.48+umd.0.0.1.nr.6',
+    version='0.0.48+umd.0.0.1.nr.7',
     author='Wavefront',
     author_email='mike@wavefront.com',
     description=('Wavefront Collector Tools'),


### PR DESCRIPTION
If there are > 200 apps, new relic will truncate. To allow for
searching of greater than 200 apps, use the name filter for
applications.json to split the apps into categories, which will
be searched on separately. In addition, add support for a server list >
200, as the query is truncated similarly.