### PR TITLE
[feature/source-tagging-api] Add functionality to tag sources

### DIFF
--- a/docs/README.newrelic.md
+++ b/docs/README.newrelic.md
@@ -84,7 +84,10 @@ This configuration file also acts as a fileconfig for the logger.  See [fileConf
 | Option | Description | Required? | Default |
 | ------ | ----------- | ------- | ------- |
 | key | Wavefront API Key | No | None |
-| endpoint | Wavefront endpont | No | https://metrics.wavefront.com/ |
+| endpoint | Wavefront endpoint | No | https://metrics.wavefront.com/ |
+| tag_sources | Turn on tag sources functionality | No | https://metrics.wavefront.com/ |
+| source_map | Map to tag sources. If source matches regex, tag with source name. | No | {} |
+
 
 #### Section: writer
 | Option | Description | Required? | Default |

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except (IOError, ImportError):
 
 setuptools.setup(
     name='wavefront_collector',
-    version='0.0.48+umd.0.0.1.nr.5',
+    version='0.0.48+umd.0.0.1.nr.6',
     author='Wavefront',
     author_email='mike@wavefront.com',
     description=('Wavefront Collector Tools'),
@@ -31,7 +31,7 @@ setuptools.setup(
     long_description=LONG_DESCRIPTION,
     keywords='wavefront wavefront_integration collector metrics',
     url='https://www.wavefront.com',
-    install_requires=['wavefront_client', 'python-dateutil', 'logging',
+    install_requires=['wavefront-api-client', 'python-dateutil', 'logging',
                       'python-daemon>=2.1.1', 'boto3', 'ndg-httpsclient'],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/test/test-conf/test-newrelic-details.conf
+++ b/test/test-conf/test-newrelic-details.conf
@@ -16,6 +16,9 @@ include_hosts = True
 workers = 20
 max_metric_names = 25
 
+[wavefront_api]
+source_map = team.test:.*testregex.*,team.test2:ttregex.*
+
 [writer]
 host = 127.0.0.1
 port = 2878

--- a/test/test_newrelic.py
+++ b/test/test_newrelic.py
@@ -8,6 +8,7 @@ from dateutil.parser import parse
 sys.path.append('..')
 from wavefront.newrelic import NewRelicMetricRetrieverCommand
 from wavefront.newrelic import NewRelicPluginConfiguration
+from wavefront_api_client.rest import ApiException
 
 
 class TestNewRelicCommand(unittest.TestCase):
@@ -82,6 +83,35 @@ class TestNewRelicCommand(unittest.TestCase):
 
         with mock.patch('wavefront.newrelic.NewRelicMetricRetrieverCommand.get_metric_names_for_path') as metric_name_call:
             assert not metric_name_call.called
+
+
+    def test_tag_source(self):
+        cmd = NewRelicMetricRetrieverCommand()
+
+        cmd.config = NewRelicPluginConfiguration(
+            config_file_path=os.path.join(os.getcwd(), 'test-conf/test-newrelic-details.conf'))
+
+        source_name = "ttregextestregex"
+
+        with mock.patch('wavefront_api_client.SourceApi.add_source_tag') as add_source_tag_call:
+            cmd.tag_source(source_name)
+
+            assert add_source_tag_call.called
+            assert add_source_tag_call.call_count == 2
+
+    def test_tag_source_failed_attempts(self):
+        cmd = NewRelicMetricRetrieverCommand()
+
+        cmd.config = NewRelicPluginConfiguration(
+            config_file_path=os.path.join(os.getcwd(), 'test-conf/test-newrelic-details.conf'))
+
+        source_name = "ttregextestregex"
+
+        with mock.patch('wavefront_api_client.SourceApi.add_source_tag', side_effect=ApiException) as add_source_tag_call:
+            cmd.tag_source(source_name)
+
+            assert add_source_tag_call.called
+            assert add_source_tag_call.call_count == 6
 
     def tearDown(self):
         self.start = None

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,29 @@
+import sys
+import unittest
+import os
+
+sys.path.append('..')
+from wavefront.utils import Configuration
+
+class TestUtils(unittest.TestCase):
+
+    def test_get_dict(self):
+        config_file_path = os.path.join(os.getcwd(), 'test-conf/test-newrelic-details.conf')
+        config = Configuration(config_file_path)
+
+        test_dict = config.getdict('wavefront-api','source_map',{})
+
+        assert test_dict['team.test'] == ".*testregex.*"
+        assert test_dict['team.test2'] == "ttregex.*"
+
+    def test_get_dict_default(self):
+        config_file_path = os.path.join(os.getcwd(), 'test-conf/test-newrelic-details.conf')
+        config = Configuration(config_file_path)
+
+        test_dict = config.getdict('wavefront-api', 'bad_source_map', {'default_key': 'default_value'})
+
+        assert test_dict['default_key'] == "default_value"
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wavefront/utils.py
+++ b/wavefront/utils.py
@@ -187,6 +187,25 @@ class Configuration(object):
         else:
             return value
 
+    def getdict(self, section, key, default_value, default_section=None,
+                pair_delimiter=',', key_value_delimiter=':'):
+        try:
+            value = self.config.get(section, key)
+            if value:
+                value = value.split(pair_delimiter)
+        except ConfigParser.NoOptionError:
+            value = None
+        except ConfigParser.NoSectionError:
+            value = None
+
+        if value is None:
+            if default_section:
+                return self.getlist(default_section, key, default_value, None)
+            else:
+                return default_value
+
+        return dict(item.split(key_value_delimiter) for item in value)
+
     def set(self, section, key, value, create_section=True):
         """
         Sets the value in the given section.  Creates the section if it does


### PR DESCRIPTION
This allows the use of regex to tag sources. Using the config, if
the source matches the regex, we tag the source with that source tag.