### PR TITLE
[fix/tag-server-with-app-name] Add tag to server details.

### DIFF
--- a/wavefront/newrelic.py
+++ b/wavefront/newrelic.py
@@ -695,6 +695,12 @@ class NewRelicMetricRetrieverCommand(NewRelicCommand):
             'server_id': server_id,
             'server_name': server_name
         }
+
+        if str(server_id) in self.server_list:
+            server_app_info = self.server_list[str(server_id)]
+            tags['app_id'] = server_app_info['app_id']
+            tags['app_name'] = server_app_info['app_name']
+
         self.get_metrics_for_path(path, fields, start, end, server_name, tags)
 
     #pylint: disable=too-many-arguments


### PR DESCRIPTION
Because the server summary and server details are not sent together
in the same method, tags need to checked and added in each instance.